### PR TITLE
prevent redefinition compiler warning in compat.h

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -12,9 +12,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#ifndef FD_SETSIZE
-#define FD_SETSIZE 1024 // max number of fds in fd_set
+#ifdef FD_SETSIZE
+#undef FD_SETSIZE // prevent redefinition compiler warning
 #endif
+#define FD_SETSIZE 1024 // max number of fds in fd_set
 #include <winsock2.h>
 #include <mswsock.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
Prevents redefinition compiler warning for FD_SETSIZE for Windows in compat.h.