### PR TITLE
Split CTransaction/CMutableTransaction.  Updated readme.md formating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**DarkSilk (DRKSLK) Release Candidate for Version 1.0.0.0**
+# **DarkSilk (DRKSLK) Release Candidate for Version 1.0.0.0**
 
 (FOR TESTING PURPOSES ONLY)
 
@@ -7,26 +7,26 @@ DarkSilk Integration/Staging Tree
 
 **Copyright (c) 2015 The DarkSilk Developers**
 
-What is DarkSilk?
+#### What is DarkSilk?
 ----------------
-Algorithm: Scrypt
-Coin Suffix: DRKSLK
-PoW Period: 42,002 Blocks
-PoW Target Spacing: 60 Seconds
-PoW Difficulty Retarget: 10 Blocks
-PoW Reward per Block: 42 DRKSLK
-Full Confirmation: 10 Blocks
-Maturity: 42 Blocks
-PoS Target Spacing: 64 Seconds
-PoS Difficulty Retarget: 10 Blocks
-PoS Reward: 1 DRKSLK Static PoS Reward
-Minimum Confirmations for Stake: 420 Blocks
-PoS Min: 4 Hours
-PoS Max: Unlimited
-Stormnode Collateral Amount: 42000 DRKSLK
-Stormnode Min Confirmation: 10 Blocks
-Total Coins: 90,000,000 DRKSLK
-Block Size: 50MB (50X Bitcoin Core)
+* Algorithm: Scrypt
+* Coin Suffix: DRKSLK
+* PoW Period: 42,002 Blocks
+* PoW Target Spacing: 60 Seconds
+* PoW Difficulty Retarget: 10 Blocks
+* PoW Reward per Block: 42 DRKSLK
+* Full Confirmation: 10 Blocks
+* Maturity: 42 Blocks
+* PoS Target Spacing: 64 Seconds
+* PoS Difficulty Retarget: 10 Blocks
+* PoS Reward: 1 DRKSLK Static PoS Reward
+* Minimum Confirmations for Stake: 420 Blocks
+* PoS Min: 4 Hours
+* PoS Max: Unlimited
+* Stormnode Collateral Amount: 42000 DRKSLK
+* Stormnode Min Confirmation: 10 Blocks
+* Total Coins: 90,000,000 DRKSLK
+* Block Size: 50MB (50X Bitcoin Core)
 
 DarkSilk is a new digital currency that enables instant payments to anyone, anywhere in the world. DarkSilk uses peer-to-peer technology over I2P/Tor/ClearNet to operate securly with no central authority (centralisation): managing transactions and issuing currency (DRKSLK) are carried out collectively by the DarkSilk network. DarkSilk is the name of open source software which enables the use of the currency DRKSLK.
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -77,7 +77,15 @@ public:
         std::vector<CTxOut> vout;
         vout.resize(1);
         vout[0].SetEmpty();
-        CTransaction txNew(1, 1444948732, vin, vout, 0);
+
+        //CTransaction txNew(1, 1444948732, vin, vout, 0);
+        CMutableTransaction txNew;
+        txNew.nVersion = 1;
+        txNew.nTime = 1444948732;
+        txNew.vin = vin;
+        txNew.vout = vout;
+        txNew.nLockTime = 0;
+
         genesis.vtx.push_back(txNew);
         genesis.hashPrevBlock = 0;
         genesis.hashMerkleRoot = genesis.BuildMerkleTree();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -938,11 +938,6 @@ bool AcceptableInputs(CTxMemPool& pool, const CTransaction &txo, bool fLimitFree
         }
     }
 
-
-    /*LogPrint("mempool", "AcceptableInputs : accepted %s (poolsz %u)\n",
-           hash.ToString(),
-           pool.mapTx.size());
-    */
     return true;
 }
 
@@ -980,6 +975,7 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
 
 CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<int*>(&nVersion) = tx.nVersion;
+    *const_cast<unsigned int*>(&nTime) = tx.nTime;
     *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
     *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
     *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
@@ -1026,9 +1022,9 @@ std::string CTransaction::ToString() const
 {
     std::string str;
     str += strprintf("CTransaction(hash=%s, time= %u ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
-        GetHash().ToString().substr(0,10),
+        GetHash().ToString().substr(0,16),
+        nTime,
         nVersion,
-        //nTime,
         vin.size(),
         vout.size(),
         nLockTime);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,6 +291,7 @@ bool CTransaction::ReadFromDisk(COutPoint prevout)
     return ReadFromDisk(txdb, prevout, txindex);
 }
 
+
 bool IsStandardTx(const CTransaction& tx, string& reason)
 {
     if (tx.nVersion > CTransaction::CURRENT_VERSION || tx.nVersion < 1) {
@@ -943,6 +944,99 @@ bool AcceptableInputs(CTxMemPool& pool, const CTransaction &txo, bool fLimitFree
            pool.mapTx.size());
     */
     return true;
+}
+
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {}
+
+uint256 CMutableTransaction::GetHash() const
+{
+    return SerializeHash(*this);
+}
+
+std::string CMutableTransaction::ToString() const
+{
+    std::string str;
+    str += strprintf("CMutableTransaction(ver=%d, time=%u vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+        nVersion,
+        nTime,
+        vin.size(),
+        vout.size(),
+        nLockTime);
+    for (unsigned int i = 0; i < vin.size(); i++)
+        str += "    " + vin[i].ToString() + "\n";
+    for (unsigned int i = 0; i < vout.size(); i++)
+        str += "    " + vout[i].ToString() + "\n";
+    return str;
+}
+
+void CTransaction::UpdateHash() const
+{
+    *const_cast<uint256*>(&hash) = SerializeHash(*this);
+}
+
+CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), nTime(tx.nTime), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {
+    UpdateHash();
+}
+
+CTransaction& CTransaction::operator=(const CTransaction &tx) {
+    *const_cast<int*>(&nVersion) = tx.nVersion;
+    *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
+    *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
+    *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
+    *const_cast<uint256*>(&hash) = tx.hash;
+    return *this;
+}
+
+uint256 CTransaction::GetHash() const
+{
+    return SerializeHash(*this);
+}
+
+CAmount CTransaction::GetValueOut() const
+{
+    CAmount nValueOut = 0;
+    for (std::vector<CTxOut>::const_iterator it(vout.begin()); it != vout.end(); ++it)
+    {
+        nValueOut += it->nValue;
+        if (!MoneyRange(it->nValue) || !MoneyRange(nValueOut))
+            throw std::runtime_error("CTransaction::GetValueOut() : value out of range");
+    }
+    return nValueOut;
+}
+
+unsigned int CTransaction::CalculateModifiedSize(unsigned int nTxSize) const
+{
+    // In order to avoid disincentivizing cleaning up the UTXO set we don't count
+    // the constant overhead for each txin and up to 110 bytes of scriptSig (which
+    // is enough to cover a compressed pubkey p2sh redemption) for priority.
+    // Providing any more cleanup incentive than making additional inputs free would
+    // risk encouraging people to create junk outputs to redeem later.
+    if (nTxSize == 0)
+        nTxSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+    for (std::vector<CTxIn>::const_iterator it(vin.begin()); it != vin.end(); ++it)
+    {
+        unsigned int offset = 41U + std::min(110U, (unsigned int)it->scriptSig.size());
+        if (nTxSize > offset)
+            nTxSize -= offset;
+    }
+    return nTxSize;
+}
+
+std::string CTransaction::ToString() const
+{
+    std::string str;
+    str += strprintf("CTransaction(hash=%s, time= %u ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+        GetHash().ToString().substr(0,10),
+        nVersion,
+        //nTime,
+        vin.size(),
+        vout.size(),
+        nLockTime);
+    for (unsigned int i = 0; i < vin.size(); i++)
+        str += "    " + vin[i].ToString() + "\n";
+    for (unsigned int i = 0; i < vout.size(); i++)
+        str += "    " + vout[i].ToString() + "\n";
+    return str;
 }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -128,6 +128,8 @@ class CTxDB;
 class CTxIndex;
 class CWalletInterface;
 
+struct CMutableTransaction;
+
 /** Register a wallet to receive updates from core */
 void RegisterWallet(CWalletInterface* pwalletIn);
 /** Unregister a wallet from core */
@@ -246,11 +248,7 @@ typedef std::map<uint256, std::pair<CTxIndex, CTransaction> > MapPrevTx;
 
 int64_t GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode);
 
-
-
-/** The basic transaction that is broadcasted on the network and contained in
- * blocks.  A transaction can contain multiple inputs and outputs.
- */
+/*
 class CTransaction
 {
 public:
@@ -318,9 +316,9 @@ public:
     // Compute priority, given priority of inputs and (optionally) tx size
     double ComputePriority(double dPriorityInputs, unsigned int nTxSize=0) const;
 
-    /** Amount of darksilks spent by this transaction.
-        @return sum of all outputs (note: does not include fees)
-     */
+    // Amount of darksilks spent by this transaction.
+    //    @return sum of all outputs (note: does not include fees)
+
     int64_t GetValueOut() const
     {
         int64_t nValueOut = 0;
@@ -333,14 +331,14 @@ public:
         return nValueOut;
     }
 
-    /** Amount of darksilks coming in to this transaction
+    /// Amount of darksilks coming in to this transaction
         Note that lightweight clients may not know anything besides the hash of previous transactions,
         so may not be able to calculate this.
 
         @param[in] mapInputs    Map of previous transactions that have outputs we're spending
         @return Sum of value of all inputs (scriptSigs)
         @see CTransaction::FetchInputs
-     */
+
     int64_t GetValueIn(const MapPrevTx& mapInputs) const;
 
     bool ReadFromDisk(CDiskTxPos pos, FILE** pfileRet=NULL)
@@ -409,7 +407,7 @@ public:
     bool ReadFromDisk(COutPoint prevout);
     bool DisconnectInputs(CTxDB& txdb);
 
-    /** Fetch from memory and/or disk. inputsRet keys are transaction hashes.
+    // Fetch from memory and/or disk. inputsRet keys are transaction hashes.
 
      @param[in] txdb    Transaction database
      @param[in] mapTestPool List of pending changes to the transaction index database
@@ -418,11 +416,11 @@ public:
      @param[out] inputsRet  Pointers to this transaction's inputs
      @param[out] fInvalid   returns true if transaction is invalid
      @return    Returns true if all inputs are in txdb or mapTestPool
-     */
+     //
     bool FetchInputs(CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
                      bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
 
-    /** Sanity check previous transactions, then, if all checks succeed,
+    //Sanity check previous transactions, then, if all checks succeed,
         mark them as spent by this transaction.
 
         @param[in] inputs   Previous transactions (from FetchInputs)
@@ -432,7 +430,7 @@ public:
         @param[in] fBlock   true if called from ConnectBlock
         @param[in] fMiner   true if called from CreateNewBlock
         @return Returns true if all checks succeed
-     */
+    //
     bool ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
                        std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
                        const CBlockIndex* pindexBlock, bool fBlock, bool fMiner, unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS, bool fValidateSig = true);
@@ -441,8 +439,233 @@ public:
 
     const CTxOut& GetOutputFor(const CTxIn& input, const MapPrevTx& inputs) const;
 };
+*/
 
+/** The basic transaction that is broadcasted on the network and contained in
+ * blocks.  A transaction can contain multiple inputs and outputs.
+ */
+class CTransaction
+{
+private:
+    /** Memory only. */
+    const uint256 hash;
+    void UpdateHash() const;
 
+public:
+    // The local variables are made const to prevent unintended modification
+    // without updating the cached hash value. However, CTransaction is not
+    // actually immutable; deserialization and assignment are implemented,
+    // and bypass the constness. This is safe, as they update the entire
+    // structure, including the hash.
+    static const int32_t CURRENT_VERSION=1;
+    int32_t nVersion;
+    uint32_t nTime;
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    uint32_t nLockTime;
+
+    // Denial-of-service detection:
+    mutable int nDoS;
+    bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
+
+    CTransaction()
+    {
+        SetNull();
+    }
+
+    /** Convert a CMutableTransaction into a CTransaction. */
+    CTransaction(const CMutableTransaction &tx);
+
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(*const_cast<int32_t*>(&this->nVersion));
+        nVersion = this->nVersion;
+        READWRITE(*const_cast<uint32_t*>(&this->nTime));
+        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
+        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
+        READWRITE(*const_cast<uint32_t*>(&nLockTime));
+        if (fRead)
+            UpdateHash();
+    )
+
+    bool ReadFromDisk(CDiskTxPos pos, FILE** pfileRet=NULL)
+    {
+        CAutoFile filein = CAutoFile(OpenBlockFile(pos.nFile, 0, pfileRet ? "rb+" : "rb"), SER_DISK, CLIENT_VERSION);
+        if (!filein)
+            return error("CTransaction::ReadFromDisk() : OpenBlockFile failed");
+
+        // Read transaction
+        if (fseek(filein, pos.nTxPos, SEEK_SET) != 0)
+            return error("CTransaction::ReadFromDisk() : fseek failed");
+
+        try {
+            filein >> *this;
+        }
+        catch (std::exception &e) {
+            return error("%s() : deserialize or I/O error", __PRETTY_FUNCTION__);
+        }
+
+        // Return file pointer
+        if (pfileRet)
+        {
+            if (fseek(filein, pos.nTxPos, SEEK_SET) != 0)
+                return error("CTransaction::ReadFromDisk() : second fseek failed");
+            *pfileRet = filein.release();
+        }
+        return true;
+    }
+
+    void SetNull()
+    {
+        nVersion = CTransaction::CURRENT_VERSION;
+        nTime = 0;//GetAdjustedTime();
+        vin.clear();
+        vout.clear();
+        nLockTime = 0;
+        nDoS = 0;  // Denial-of-service prevention
+    }
+
+    bool IsNull() const
+    {
+        return (vin.empty() && vout.empty());
+    }
+
+    uint256 GetHash() const;
+
+    bool IsCoinBase() const
+    {
+        return (vin.size() == 1 && vin[0].prevout.IsNull() && vout.size() >= 1);
+    }
+
+    bool IsCoinStake() const
+    {
+        // ppcoin: the coin stake transaction is marked with the first output empty
+        return (vin.size() > 0 && (!vin[0].prevout.IsNull()) && vout.size() >= 2 /*&& vout[0].IsEmpty()*/);
+    }
+
+    unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;
+
+    /** Amount of bitcoins spent by this transaction.
+        @return sum of all outputs (note: does not include fees)
+     */
+    int64_t GetValueOut() const;
+
+    std::string ToString() const;
+
+    double ComputePriority(double dPriorityInputs, unsigned int nTxSize) const;
+
+    CTransaction& operator=(const CTransaction& tx);
+
+    const CTxOut& GetOutputFor(const CTxIn& input, const MapPrevTx& inputs) const;
+    int64_t GetValueIn(const MapPrevTx& mapInputs) const;
+
+    bool ReadFromDisk(CTxDB& txdb, const uint256& hash, CTxIndex& txindexRet);
+    bool ReadFromDisk(CTxDB& txdb, COutPoint prevout, CTxIndex& txindexRet);
+    bool ReadFromDisk(CTxDB& txdb, COutPoint prevout);
+    bool ReadFromDisk(COutPoint prevout);
+
+    bool DisconnectInputs(CTxDB& txdb);
+
+    bool FetchInputs(CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
+                     bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
+
+    friend bool operator==(const CTransaction& a, const CTransaction& b)
+    {
+        return a.hash == b.hash;
+    }
+
+    friend bool operator!=(const CTransaction& a, const CTransaction& b)
+    {
+        return a.hash != b.hash;
+    }
+
+    bool CheckTransaction() const;
+    bool GetCoinAge(CTxDB& txdb, const CBlockIndex* pindexPrev, uint64_t& nCoinAge) const;
+
+    bool ConnectInputs(CTxDB& txdb, MapPrevTx inputs,
+                       std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
+                       const CBlockIndex* pindexBlock, bool fBlock, bool fMiner, unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS, bool fValidateSig = true);
+
+};
+
+/** A mutable version of CTransaction. */
+struct CMutableTransaction
+{
+    static const int32_t CURRENT_VERSION=1;
+    int32_t nVersion;
+    uint32_t nTime;
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    uint32_t nLockTime;
+
+    // Denial-of-service detection:
+    mutable int nDoS;
+    bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
+
+    CMutableTransaction()
+    {
+        SetNull();
+    }
+
+    /** Convert a CTransaction into a CMutableTransaction. */
+    CMutableTransaction(const CTransaction& tx);
+
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nTime);
+        READWRITE(vin);
+        READWRITE(vout);
+        READWRITE(nLockTime);
+    )
+
+    void SetNull()
+    {
+        nVersion = CMutableTransaction::CURRENT_VERSION;
+        nTime = 0;//GetAdjustedTime();
+        vin.clear();
+        vout.clear();
+        nLockTime = 0;
+        nDoS = 0;  // Denial-of-service prevention
+    }
+
+    bool IsNull() const
+    {
+        return (vin.empty() && vout.empty());
+    }
+
+    uint256 GetHash() const;
+
+    bool IsCoinBase() const
+    {
+        return (vin.size() == 1 && vin[0].prevout.IsNull() && vout.size() >= 1);
+    }
+
+    bool IsCoinStake() const
+    {
+        // ppcoin: the coin stake transaction is marked with the first output empty
+        return (vin.size() > 0 && (!vin[0].prevout.IsNull()) && vout.size() >= 2 /*&& vout[0].IsEmpty()*/);
+    }
+
+    /** Amount of bitcoins spent by this transaction.
+        @return sum of all outputs (note: does not include fees)
+     */
+    int64_t GetValueOut() const;
+
+    std::string ToString() const;
+
+    friend bool operator==(const CMutableTransaction& a, const CMutableTransaction& b)
+    {
+        return a.GetHash() == b.GetHash();
+    }
+
+    friend bool operator!=(const CMutableTransaction& a, const CMutableTransaction& b)
+    {
+        return !(a == b);
+    }
+
+};
 
 
 /** wrapper for CTxOut that provides a more compact serialization */


### PR DESCRIPTION
I still need to make CTransaction immutable and use CMutableTransaction when a new tx is created.  This should compile and run.  It doesn't alter the block hashes either.