### PR TITLE
Fixes segfault in txleveldb.

### DIFF
--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -66,6 +66,8 @@ static void init_blockindex(leveldb::Options& options, bool fRemoveOld = false, 
         }
     }
 
+    options.create_if_missing = true;
+
     filesystem::create_directory(directory);
     LogPrintf("Opening LevelDB in %s\n", directory.string());
     leveldb::Status status = leveldb::DB::Open(options, directory.string(), &txdb);


### PR DESCRIPTION
Fixes this error:

EXCEPTION: St13runtime_error
init_blockindex(): error opening database environment IO error: lock /
home/dev/.darksilk/txleveldb/LOCK: Resource temporarily unavailable
darksilk in Runaway exception