### PR TITLE
Bug Fix: Stops sending double transactions.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -517,9 +517,6 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    if (strError != "")
-        throw JSONRPCError(RPC_WALLET_ERROR, strError);
-
     EnsureWalletIsUnlocked();
 
     SendMoney(address.Get(), nAmount, wtx, fUseIX, fUseSS);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -517,8 +517,6 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, sNarr, wtx);
-    
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
 


### PR DESCRIPTION
RPCWallet was the issue.  In the sendtoaddress API call, SendMoney() was being called twice.  This removes the old call to pwalletMain->SendMoneyToDestination and keeps the newer.  SendMoneyToDestination calls SendMoney.