### PR TITLE
Fix truncated file error for obj/key.o preventing Daemon build

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -14,11 +14,6 @@
 #include "pubkey.h"
 #include "util.h"
 
-#include <openssl/ecdsa.h>
-#include <openssl/obj_mac.h>
-#include <openssl/ssl.h>
-#include <openssl/ecdh.h>
-
 // anonymous namespace
 namespace {
 class CSecp256k1Init {


### PR DESCRIPTION
#### What's this pull request do?
Removes the includes for opensll which are no longer needed as we use secp256k1 and caused truncation of obj/key.o when building darksilkd (Daemon)
#### Where should the reviewer start?
Test build Daemon, connect and sync, test send tx to own address and stealth address.
#### Did you test this pull request?
Daemon builds successfully.
#### Any background context you want to provide?
#### Screenshots (if appropriate)
#### Questions:
- Does the readme or documentaion need an update?
No
- Does this add new C++ dependencies which need to be added?
No
- Does this change the chain or fork the network?
No

