### PR TITLE
Stormnode Payment Selection Changed to PoW Block Hashes

### DIFF
--- a/src/anon/stormnode/stormnode-budget.cpp
+++ b/src/anon/stormnode/stormnode-budget.cpp
@@ -453,7 +453,7 @@ void CBudgetManager::FillBlockPayee(CTransaction& txNew, CAmount nFees)
         ++it;
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees);
+    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees, true);
 
     if(nHighestCount > 0){
 

--- a/src/anon/stormnode/stormnode-budget.cpp
+++ b/src/anon/stormnode/stormnode-budget.cpp
@@ -453,41 +453,22 @@ void CBudgetManager::FillBlockPayee(CTransaction& txNew, CAmount nFees)
         ++it;
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees, true);
+    CAmount blockValue = GetProofOfWorkReward(nFees);
+
+    txNew.vout[0].nValue = blockValue;
 
     if(nHighestCount > 0){
+        txNew.vout.resize(2);
 
+        //these are super blocks, so their value can be much larger than normal
         txNew.vout[1].scriptPubKey = payee;
+        txNew.vout[1].nValue = nAmount;
 
-        //these are super blocks, PoS and budget payments only.  No stormnode payments. (TODO (Amir): add SN payment here)
-        if(txNew.vout.size() == 4) // 2 stake outputs, stake was split, plus 3x budget payments
-        {
-            txNew.vout[1].nValue = nAmount;
-            txNew.vout[2].nValue = (blockValue / 2 / CENT) * CENT;
-            txNew.vout[3].nValue = blockValue;
-        }
-        else if(txNew.vout.size() == 3) // only 1 stake output, was not split, plus 3x budget payments
-        {
-            txNew.vout[1].nValue = nAmount;
-            txNew.vout[2].nValue = blockValue;
-        }
-        CTxDestination ctxdAddress1;
-        ExtractDestination(payee, ctxdAddress1);
-        CDarkSilkAddress address1(ctxdAddress1);
-        LogPrintf("Budget payment 1 to %s for %lld\n", address1.ToString().c_str(), nAmount);
-    }
-    else
-    {
-        //No budget finalized and approved, so we only pay PoS minters. (add SN payment here)
-        if(txNew.vout.size() == 3) // 2 stake outputs, stake was split, plus 3x budget payments
-        {
-            txNew.vout[1].nValue = (blockValue / 2 / CENT) * CENT;
-            txNew.vout[2].nValue = blockValue;
-        }
-        else if(txNew.vout.size() == 2) // only 1 stake output, was not split, plus 3x budget payments
-        {
-            txNew.vout[1].nValue = blockValue;
-        }
+        CTxDestination address1;
+        ExtractDestination(payee, address1);
+        CDarkSilkAddress address2(address1);
+
+        LogPrintf("CBudgetManager::FillBlockPayee - Budget payment to %s for %lld\n", address2.ToString(), nAmount);
     }
 }
 

--- a/src/anon/stormnode/stormnode-payments.cpp
+++ b/src/anon/stormnode/stormnode-payments.cpp
@@ -270,7 +270,6 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight)
     return false;
 }
 
-
 void FillBlockPayee(CTransaction& txNew, CAmount nFees) //TODO (Amir): Use CMutableTransaction here
 {
     if(!pindexBest) return;
@@ -312,32 +311,19 @@ void CStormnodePayments::FillBlockPayee(CTransaction& txNew, CAmount nFees)
         }
     }
 
-    if(hasPayment){
+    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees);
+    CAmount stormnodePayment = GetStormnodePayment(pindexPrev->nHeight+1, blockValue);
 
-        //txNew.vout.resize(2);
+    txNew.vout[0].nValue = blockValue;
+
+    if(hasPayment){
+        txNew.vout.resize(2);
 
         txNew.vout[1].scriptPubKey = payee;
-        //txNew.vout[1].nValue = stormnodePayment;
+        txNew.vout[1].nValue = stormnodePayment;
 
-        //txNew.vout[0].nValue -= stormnodePayment;
+        txNew.vout[0].nValue -= stormnodePayment;
 
-        // Stormnode Payments
-        CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees);
-        CAmount stormnodePayment = GetStormnodePayment(pindexPrev->nHeight+1, blockValue);
-
-        if(txNew.vout.size() == 4) // 2 stake outputs, stake was split, plus a stormnode payment
-        {
-            txNew.vout[1].nValue = stormnodePayment;
-            blockValue -= stormnodePayment;
-            txNew.vout[2].nValue = (blockValue / 2 / CENT) * CENT;
-            txNew.vout[3].nValue = blockValue - txNew.vout[1].nValue;
-        }
-        else if(txNew.vout.size() == 3) // only 1 stake output, was not split, plus a stormnode payment
-        {
-            txNew.vout[1].nValue = stormnodePayment;
-            blockValue -= stormnodePayment;
-            txNew.vout[2].nValue = blockValue;
-        }
         CTxDestination address1;
         ExtractDestination(payee, address1);
         CDarkSilkAddress address2(address1);

--- a/src/anon/stormnode/stormnode-payments.cpp
+++ b/src/anon/stormnode/stormnode-payments.cpp
@@ -311,7 +311,7 @@ void CStormnodePayments::FillBlockPayee(CTransaction& txNew, CAmount nFees)
         }
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees);
+    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees, true);
     CAmount stormnodePayment = GetStormnodePayment(pindexPrev->nHeight+1, blockValue);
 
     txNew.vout[0].nValue = blockValue;

--- a/src/anon/stormnode/stormnode-payments.cpp
+++ b/src/anon/stormnode/stormnode-payments.cpp
@@ -306,12 +306,14 @@ void CStormnodePayments::FillBlockPayee(CTransaction& txNew, CAmount nFees)
         if(winningNode){
             payee = GetScriptForDestination(winningNode->pubkey.GetID());
         } else {
-            LogPrintf("CreateNewBlock: Failed to detect stormnode to pay\n");
+            if (fDebug)
+                LogPrintf("CreateNewBlock: Failed to detect stormnode to pay\n");
+
             hasPayment = false;
         }
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees, true);
+    CAmount blockValue = GetProofOfWorkReward(nFees);
     CAmount stormnodePayment = GetStormnodePayment(pindexPrev->nHeight+1, blockValue);
 
     txNew.vout[0].nValue = blockValue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1692,9 +1692,8 @@ CAmount GetProofOfWorkReward(CAmount nFees)
     }
     else
     {
-        CAmount nSubsidy = 1 * COIN;
-        LogPrint("creation", "GetProofOfWorkReward() : create=%s nSubsidy=%d\n", FormatMoney(nSubsidy), nSubsidy);
-        return nSubsidy + nFees;
+        LogPrint("creation", "GetProofOfWorkReward() : create=%s nSubsidy=%d\n", FormatMoney(STATIC_POW_REWARD), STATIC_POW_REWARD);
+        return STATIC_POW_REWARD + nFees;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1746,17 +1746,19 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
     return bnNew.GetCompact();
 }
 
-CAmount GetBlockValue(int nBits, int nHeight, const CAmount& nFees)
+CAmount GetBlockValue(int nBits, int nHeight, const CAmount& nFees, bool fProofOfWork)
 {
-    CAmount nSubsidy = STATIC_POS_REWARD;
-
-    return nSubsidy + nFees;
+    if (fProofOfWork) {
+        return STATIC_POW_REWARD + nFees;
+    }
+    else {
+        return STATIC_POS_REWARD + nFees;
+    }
 }
-
 
 CAmount GetStormnodePayment(int nHeight, CAmount blockValue)
 {
-    CAmount ret = blockValue * 2/4; //50%
+    CAmount ret = blockValue * 1/5; //20%
 
     return ret;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -37,6 +37,8 @@ static const CAmount SANDSTORM_COLLATERAL = (0.01*COIN);
 static const CAmount SANDSTORM_POOL_MAX = (9999.99*COIN);
 // Static Proof-of-Stake Reward of 0.01 DRKSLK
 static const CAmount STATIC_POS_REWARD = COIN * 0.01;
+// Static Proof-of-Work Reward of 1.0 DRKSLK
+static const CAmount STATIC_POW_REWARD = COIN * 1;
 // Number of blocks that can be requested at any given time from a single peer.
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 128;
 // Timeout in seconds before considering a block download peer unresponsive.
@@ -175,7 +177,7 @@ void ThreadStakeMiner(CWallet *pwallet);
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, CTransaction &tx, bool fLimitFree, bool* pfMissingInputs, bool ignoreFees = false);
 bool AcceptableInputs(CTxMemPool& pool, CValidationState &state, CTransaction &tx, bool fLimitFree, bool* pfMissingInputs, bool fRejectInsaneFee=false, bool isSSTX=false);
 
-CAmount GetBlockValue(int nBits, int nHeight, const CAmount& nFees);
+CAmount GetBlockValue(int nBits, int nHeight, const CAmount& nFees, bool fProofOfWork = true);
 
 bool FindTransactionsByDestination(const CTxDestination &dest, std::vector<uint256> &vtxhash);
 

--- a/src/main.h
+++ b/src/main.h
@@ -38,7 +38,7 @@ static const CAmount SANDSTORM_POOL_MAX = (9999.99*COIN);
 // Static Proof-of-Stake Reward of 0.01 DRKSLK
 static const CAmount STATIC_POS_REWARD = COIN * 0.01;
 // Static Proof-of-Work Reward of 1.0 DRKSLK
-static const CAmount STATIC_POW_REWARD = COIN * 1;
+static const CAmount STATIC_POW_REWARD = COIN * 1; //TODO (Amir): Change to 1.25 before release.
 // Number of blocks that can be requested at any given time from a single peer.
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 128;
 // Timeout in seconds before considering a block download peer unresponsive.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -357,6 +357,9 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
             }
         }
 
+        nLastBlockTx = nBlockTx;
+        nLastBlockSize = nBlockSize;
+
         if (!fProofOfStake){
             // PoW block, Stormnode and general budget payments
             FillBlockPayee(txNew, nFees);
@@ -368,10 +371,6 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
             if ((fDebug && GetBoolArg("-printpriority", false)))
                 LogPrintf("CreateNewBlock(): PoS, total size %u, height: %u \n", nBlockSize, nHeight);
         }
-
-        //TODO (Amir): Are these lines needed???
-        //nLastBlockTx = nBlockTx;
-        //nLastBlockSize = nBlockSize;
 
         if (pFees)
             *pFees = nFees;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -103,8 +103,8 @@ public:
     }
 };
 
-// CreateNewBlock: create new block (without proof-of-work/proof-of-stake)
-CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFees)
+// CreateNewBlockPoS: create new proof-of-stake block
+CBlock* CreateNewBlockPoS(CReserveKey& reservekey, CAmount* pFees)
 {
     // Create new block
     auto_ptr<CBlock> pblock(new CBlock());
@@ -115,28 +115,16 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
     int nHeight = pindexPrev->nHeight + 1;
 
     // Create coinbase tx
-    // TODO (AA): Use CMutableTransaction txNew;
     CMutableTransaction txNew;
     txNew.vin.resize(1);
     txNew.vin[0].prevout.SetNull();
     txNew.vout.resize(1);
 
-    if (!fProofOfStake)
-    {
-        pblock->nVersion = 1; // Proof of Work uses Argon2d
-        CPubKey pubkey;
-        if (!reservekey.GetReservedKey(pubkey))
-            return NULL;
-        txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
-    }
-    else
-    {
-        // Height first in coinbase required for block.version=2
-        txNew.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
-        assert(txNew.vin[0].scriptSig.size() <= 100);
+    // Height first in coinbase required for block.version=2
+    txNew.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
+    assert(txNew.vin[0].scriptSig.size() <= 100);
 
-        txNew.vout[0].SetEmpty();
-    }
+    txNew.vout[0].SetEmpty();
 
     // Add our coinbase tx as first transaction
     pblock->vtx.push_back(txNew);
@@ -165,7 +153,7 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
     if (mapArgs.count("-mintxfee"))
         ParseMoney(mapArgs["-mintxfee"], nMinTxFee);
 
-    pblock->nBits = GetNextTargetRequired(pindexPrev, fProofOfStake);
+    pblock->nBits = GetNextTargetRequired(pindexPrev, true);
 
 
     // Collect memory pool transactions into the block
@@ -283,7 +271,7 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
                 continue;
 
             // Timestamp limit
-            if (tx.nTime > GetAdjustedTime() || (fProofOfStake && tx.nTime > pblock->vtx[0].nTime))
+            if (tx.nTime > GetAdjustedTime() || (true && tx.nTime > pblock->vtx[0].nTime))
                 continue;
 
             // Skip free transactions if we're past the minimum block size:
@@ -357,15 +345,11 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
             }
         }
 
-        CAmount blockValue = GetBlockValue(pindexPrev->nBits, pindexPrev->nHeight, nFees);
-        CAmount stormnodePayment = GetStormnodePayment(pindexPrev->nHeight+1, blockValue);
+        nLastBlockTx = nBlockTx;
+        nLastBlockSize = nBlockSize;
 
-        if ((fDebug && GetBoolArg("-printpriority", false)))
-            LogPrintf("CreateNewBlock(): total size %u, height: %u, PoS: %d, block value: %u, stormnode payment: %u \n",
-                      nBlockSize, nHeight, fProofOfStake, blockValue, stormnodePayment);
-
-        if (!fProofOfStake)
-            pblock->vtx[0].vout[0].nValue = GetProofOfWorkReward(nFees);
+        if (fDebug && GetBoolArg("-printpriority", false))
+            LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);
 
         if (pFees)
             *pFees = nFees;
@@ -373,8 +357,277 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
         pblock->nTime          = max(pindexPrev->GetPastTimeLimit()+1, pblock->GetMaxTransactionTime());
-        if (!fProofOfStake)
-            pblock->UpdateTime(pindexPrev);
+        pblock->nNonce         = 0;
+    }
+
+    return pblock.release();
+}
+
+// CreateNewBlock: create new proof-of-work block
+CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
+{
+    // Create new block
+    auto_ptr<CBlock> pblock(new CBlock());
+    if (!pblock.get())
+        return NULL;
+
+    CBlockIndex* pindexPrev = pindexBest;
+    int nHeight = pindexPrev->nHeight + 1;
+
+    // Create coinbase tx
+    // TODO (AA): Use CMutableTransaction txNew;
+    CTransaction txNew;
+    txNew.vin.resize(1);
+    txNew.vin[0].prevout.SetNull();
+    txNew.vout.resize(1);
+
+    pblock->nVersion = 1; // Proof of Work uses Argon2d
+    CPubKey pubkey;
+    if (!reservekey.GetReservedKey(pubkey))
+        return NULL;
+    txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
+
+    // Add our coinbase tx as first transaction
+    pblock->vtx.push_back(txNew);
+
+    // Largest block you're willing to create:
+    unsigned int nBlockMaxSize = GetArg("-blockmaxsize", MAX_BLOCK_SIZE_GEN/2);
+    // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
+    nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
+
+    // How much of the block should be dedicated to high-priority transactions,
+    // included regardless of the fees they pay
+    unsigned int nBlockPrioritySize = GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
+    nBlockPrioritySize = std::min(nBlockMaxSize, nBlockPrioritySize);
+
+    // Minimum block size you want to create; block will be filled with free transactions
+    // until there are no more or the block reaches this size:
+    unsigned int nBlockMinSize = GetArg("-blockminsize", 0);
+    nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
+
+    // Fee-per-kilobyte amount considered the same as "free"
+    // Be careful setting this: if you set it to zero then
+    // a transaction spammer can cheaply fill blocks using
+    // 1-satoshi-fee transactions. It should be set above the real
+    // cost to you of processing a transaction.
+    CAmount nMinTxFee = MIN_TX_FEE;
+    if (mapArgs.count("-mintxfee"))
+        ParseMoney(mapArgs["-mintxfee"], nMinTxFee);
+
+    pblock->nBits = GetNextTargetRequired(pindexPrev, false);
+
+    // Collect memory pool transactions into the block
+    CAmount nFees = 0;
+    {
+        LOCK2(cs_main, mempool.cs);
+        CTxDB txdb("r");
+
+        // Priority order to process transactions
+        list<COrphan> vOrphan; // list memory doesn't move
+        map<uint256, vector<COrphan*> > mapDependers;
+
+        // This vector will be sorted into a priority queue:
+        vector<TxPriority> vecPriority;
+        vecPriority.reserve(mempool.mapTx.size());
+        for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
+        {
+            CTransaction& tx = (*mi).second;
+            if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, nHeight))
+                continue;
+
+            COrphan* porphan = NULL;
+            double dPriority = 0;
+            CAmount nTotalIn = 0;
+            bool fMissingInputs = false;
+            BOOST_FOREACH(const CTxIn& txin, tx.vin)
+            {
+                // Read prev transaction
+                CTransaction txPrev;
+                CTxIndex txindex;
+                CTransactionPoS txPoS;
+                if (!txPoS.ReadFromDisk(txPrev, txdb, txin.prevout, txindex))
+                {
+                    // This should never happen; all transactions in the memory
+                    // pool should connect to either transactions in the chain
+                    // or other transactions in the memory pool.
+                    if (!mempool.mapTx.count(txin.prevout.hash))
+                    {
+                        LogPrintf("ERROR: mempool transaction missing input\n");
+                        if (fDebug) assert("mempool transaction missing input" == 0);
+                        fMissingInputs = true;
+                        if (porphan)
+                            vOrphan.pop_back();
+                        break;
+                    }
+
+                    // Has to wait for dependencies
+                    if (!porphan)
+                    {
+                        // Use list for automatic deletion
+                        vOrphan.push_back(COrphan(&tx));
+                        porphan = &vOrphan.back();
+                    }
+                    mapDependers[txin.prevout.hash].push_back(porphan);
+                    porphan->setDependsOn.insert(txin.prevout.hash);
+                    nTotalIn += mempool.mapTx[txin.prevout.hash].vout[txin.prevout.n].nValue;
+                    continue;
+                }
+                CAmount nValueIn = txPrev.vout[txin.prevout.n].nValue;
+                nTotalIn += nValueIn;
+
+                int nConf = txindex.GetDepthInMainChain();
+                dPriority += (double)nValueIn * nConf;
+            }
+            if (fMissingInputs) continue;
+
+            // Priority is sum(valuein * age) / txsize
+            unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+            dPriority /= nTxSize;
+
+            // This is a more accurate fee-per-kilobyte than is used by the client code, because the
+            // client code rounds up the size to the nearest 1K. That's good, because it gives an
+            // incentive to create smaller transactions.
+            CTransactionPoS txPoS;
+            double dFeePerKb =  double(nTotalIn-txPoS.GetValueOut(tx)) / (double(nTxSize)/1000.0);
+
+            if (porphan)
+            {
+                porphan->dPriority = dPriority;
+                porphan->dFeePerKb = dFeePerKb;
+            }
+            else {
+                vecPriority.push_back(TxPriority(dPriority, dFeePerKb, &(*mi).second));
+            }
+        }
+
+        // Collect transactions into block
+        map<uint256, CTxIndex> mapTestPool;
+        uint64_t nBlockSize = 1000;
+        uint64_t nBlockTx = 0;
+        int nBlockSigOps = 100;
+        bool fSortedByFee = (nBlockPrioritySize <= 0);
+
+        TxPriorityCompare comparer(fSortedByFee);
+        std::make_heap(vecPriority.begin(), vecPriority.end(), comparer);
+
+        while (!vecPriority.empty())
+        {
+            // Take highest priority transaction off the priority queue:
+            double dPriority = vecPriority.front().get<0>();
+            double dFeePerKb = vecPriority.front().get<1>();
+            CTransaction& tx = *(vecPriority.front().get<2>());
+
+            std::pop_heap(vecPriority.begin(), vecPriority.end(), comparer);
+            vecPriority.pop_back();
+
+            // Size limits
+            unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+            if (nBlockSize + nTxSize >= nBlockMaxSize)
+                continue;
+
+            // Legacy limits on sigOps:
+            unsigned int nTxSigOps = GetLegacySigOpCount(tx);
+            if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
+                continue;
+
+            // Timestamp limit
+            if (tx.nTime > GetAdjustedTime() || (false && tx.nTime > pblock->vtx[0].nTime))
+                continue;
+
+            // Skip free transactions if we're past the minimum block size:
+            if (fSortedByFee && (dFeePerKb < nMinTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
+                continue;
+
+            // Prioritize by fee once past the priority size or we run out of high-priority
+            // transactions:
+            if (!fSortedByFee &&
+                ((nBlockSize + nTxSize >= nBlockPrioritySize) || (dPriority < COIN * 144 / 250)))
+            {
+                fSortedByFee = true;
+                comparer = TxPriorityCompare(fSortedByFee);
+                std::make_heap(vecPriority.begin(), vecPriority.end(), comparer);
+            }
+
+            // Connecting shouldn't fail due to dependency on other memory pool transactions
+            // because we're already processing them in order of dependency
+            map<uint256, CTxIndex> mapTestPoolTmp(mapTestPool);
+            MapPrevTx mapInputs;
+
+            bool fInvalid;
+            CTransactionPoS txPoS;
+            if (!txPoS.FetchInputs(tx, txdb, mapTestPoolTmp, false, true, mapInputs, fInvalid))
+                continue;
+
+            CAmount nTxFees = txPoS.GetValueIn(tx, mapInputs) - txPoS.GetValueOut(tx);
+
+            nTxSigOps += GetP2SHSigOpCount(tx, mapInputs);
+            if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
+                continue;
+
+            // Note that flags: we don't want to set mempool/IsStandard()
+            // policy here, but we still have to ensure that the block we
+            // create only contains transactions that are valid in new blocks.
+            if (!txPoS.ConnectInputs(tx, txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1,1,1), pindexPrev, false, true, MANDATORY_SCRIPT_VERIFY_FLAGS))
+                continue;
+
+            mapTestPoolTmp[tx.GetHash()] = CTxIndex(CDiskTxPos(1,1,1), tx.vout.size());
+            swap(mapTestPool, mapTestPoolTmp);
+
+            // Added
+            pblock->vtx.push_back(tx);
+            nBlockSize += nTxSize;
+            ++nBlockTx;
+            nBlockSigOps += nTxSigOps;
+            nFees += nTxFees;
+
+            if (fDebug && GetBoolArg("-printpriority", false))
+            {
+                LogPrintf("priority %.1f feeperkb %.1f txid %s\n",
+                       dPriority, dFeePerKb, tx.GetHash().ToString());
+            }
+
+            // Add transactions that depend on this one to the priority queue
+            uint256 hash = tx.GetHash();
+            if (mapDependers.count(hash))
+            {
+                BOOST_FOREACH(COrphan* porphan, mapDependers[hash])
+                {
+                    if (!porphan->setDependsOn.empty())
+                    {
+                        porphan->setDependsOn.erase(hash);
+                        if (porphan->setDependsOn.empty())
+                        {
+                            vecPriority.push_back(TxPriority(porphan->dPriority, porphan->dFeePerKb, porphan->ptx));
+                            std::push_heap(vecPriority.begin(), vecPriority.end(), comparer);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Stormnode and general budget payments
+        FillBlockPayee(txNew, nFees);
+
+        // Make payee
+        if(txNew.vout.size() > 1){
+            pblock->payee = txNew.vout[1].scriptPubKey;
+        }
+
+        nLastBlockTx = nBlockTx;
+        nLastBlockSize = nBlockSize;
+        LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);
+
+        // Compute final coinbase transaction.
+        txNew.vin[0].scriptSig = CScript() << nHeight << OP_0;
+        pblock->vtx[0] = txNew;
+
+        if (pFees)
+            *pFees = nFees;
+
+        // Fill in header
+        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
+        pblock->nTime          = max(pindexPrev->GetPastTimeLimit()+1, pblock->GetMaxTransactionTime());
+        pblock->UpdateTime(pindexPrev);
         pblock->nNonce         = 0;
     }
 
@@ -539,7 +792,7 @@ void ThreadStakeMiner(CWallet *pwallet)
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
     // Make this thread recognisable as the mining thread
-    RenameThread("darksilk-miner");
+    RenameThread("pos-miner");
 
     CReserveKey reservekey(pwallet);
 
@@ -574,7 +827,7 @@ void ThreadStakeMiner(CWallet *pwallet)
         // Create new block
         //
         CAmount nFees;
-        auto_ptr<CBlock> pblock(CreateNewBlock(reservekey, true, &nFees));
+        auto_ptr<CBlock> pblock(CreateNewBlockPoS(reservekey, &nFees));
         if (!pblock.get())
             return;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -103,268 +103,8 @@ public:
     }
 };
 
-// CreateNewBlockPoS: create new proof-of-stake block
-CBlock* CreateNewBlockPoS(CReserveKey& reservekey, CAmount* pFees)
-{
-    // Create new block
-    auto_ptr<CBlock> pblock(new CBlock());
-    if (!pblock.get())
-        return NULL;
-
-    CBlockIndex* pindexPrev = pindexBest;
-    int nHeight = pindexPrev->nHeight + 1;
-
-    // Create coinbase tx
-    CMutableTransaction txNew;
-    txNew.vin.resize(1);
-    txNew.vin[0].prevout.SetNull();
-    txNew.vout.resize(1);
-
-    // Height first in coinbase required for block.version=2
-    txNew.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
-    assert(txNew.vin[0].scriptSig.size() <= 100);
-
-    txNew.vout[0].SetEmpty();
-
-    // Add our coinbase tx as first transaction
-    pblock->vtx.push_back(txNew);
-
-    // Largest block you're willing to create:
-    unsigned int nBlockMaxSize = GetArg("-blockmaxsize", MAX_BLOCK_SIZE_GEN/2);
-    // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
-    nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
-
-    // How much of the block should be dedicated to high-priority transactions,
-    // included regardless of the fees they pay
-    unsigned int nBlockPrioritySize = GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
-    nBlockPrioritySize = std::min(nBlockMaxSize, nBlockPrioritySize);
-
-    // Minimum block size you want to create; block will be filled with free transactions
-    // until there are no more or the block reaches this size:
-    unsigned int nBlockMinSize = GetArg("-blockminsize", 0);
-    nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
-
-    // Fee-per-kilobyte amount considered the same as "free"
-    // Be careful setting this: if you set it to zero then
-    // a transaction spammer can cheaply fill blocks using
-    // 1-satoshi-fee transactions. It should be set above the real
-    // cost to you of processing a transaction.
-    CAmount nMinTxFee = MIN_TX_FEE;
-    if (mapArgs.count("-mintxfee"))
-        ParseMoney(mapArgs["-mintxfee"], nMinTxFee);
-
-    pblock->nBits = GetNextTargetRequired(pindexPrev, true);
-
-
-    // Collect memory pool transactions into the block
-    CAmount nFees = 0;
-    {
-        LOCK2(cs_main, mempool.cs);
-        CTxDB txdb("r");
-
-        // Priority order to process transactions
-        list<COrphan> vOrphan; // list memory doesn't move
-        map<uint256, vector<COrphan*> > mapDependers;
-
-        // This vector will be sorted into a priority queue:
-        vector<TxPriority> vecPriority;
-        vecPriority.reserve(mempool.mapTx.size());
-        for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
-        {
-            CTransaction& tx = (*mi).second;
-            if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, nHeight))
-                continue;
-
-            COrphan* porphan = NULL;
-            double dPriority = 0;
-            CAmount nTotalIn = 0;
-            bool fMissingInputs = false;
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-            {
-                // Read prev transaction
-                CTransaction txPrev;
-                CTxIndex txindex;
-                CTransactionPoS txPoS;
-                if (!txPoS.ReadFromDisk(txPrev, txdb, txin.prevout, txindex))
-                {
-                    // This should never happen; all transactions in the memory
-                    // pool should connect to either transactions in the chain
-                    // or other transactions in the memory pool.
-                    if (!mempool.mapTx.count(txin.prevout.hash))
-                    {
-                        LogPrintf("ERROR: mempool transaction missing input\n");
-                        if (fDebug) assert("mempool transaction missing input" == 0);
-                        fMissingInputs = true;
-                        if (porphan)
-                            vOrphan.pop_back();
-                        break;
-                    }
-
-                    // Has to wait for dependencies
-                    if (!porphan)
-                    {
-                        // Use list for automatic deletion
-                        vOrphan.push_back(COrphan(&tx));
-                        porphan = &vOrphan.back();
-                    }
-                    mapDependers[txin.prevout.hash].push_back(porphan);
-                    porphan->setDependsOn.insert(txin.prevout.hash);
-                    nTotalIn += mempool.mapTx[txin.prevout.hash].vout[txin.prevout.n].nValue;
-                    continue;
-                }
-                CAmount nValueIn = txPrev.vout[txin.prevout.n].nValue;
-                nTotalIn += nValueIn;
-
-                int nConf = txindex.GetDepthInMainChain();
-                dPriority += (double)nValueIn * nConf;
-            }
-            if (fMissingInputs) continue;
-
-            // Priority is sum(valuein * age) / txsize
-            unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
-            dPriority /= nTxSize;
-
-            // This is a more accurate fee-per-kilobyte than is used by the client code, because the
-            // client code rounds up the size to the nearest 1K. That's good, because it gives an
-            // incentive to create smaller transactions.
-            CTransactionPoS txPoS;
-            double dFeePerKb =  double(nTotalIn-txPoS.GetValueOut(tx)) / (double(nTxSize)/1000.0);
-
-            if (porphan)
-            {
-                porphan->dPriority = dPriority;
-                porphan->dFeePerKb = dFeePerKb;
-            }
-            else {
-                vecPriority.push_back(TxPriority(dPriority, dFeePerKb, &(*mi).second));
-            }
-        }
-
-        // Collect transactions into block
-        map<uint256, CTxIndex> mapTestPool;
-        uint64_t nBlockSize = 1000;
-        uint64_t nBlockTx = 0;
-        int nBlockSigOps = 100;
-        bool fSortedByFee = (nBlockPrioritySize <= 0);
-
-        TxPriorityCompare comparer(fSortedByFee);
-        std::make_heap(vecPriority.begin(), vecPriority.end(), comparer);
-
-        while (!vecPriority.empty())
-        {
-            // Take highest priority transaction off the priority queue:
-            double dPriority = vecPriority.front().get<0>();
-            double dFeePerKb = vecPriority.front().get<1>();
-            CTransaction& tx = *(vecPriority.front().get<2>());
-
-            std::pop_heap(vecPriority.begin(), vecPriority.end(), comparer);
-            vecPriority.pop_back();
-
-            // Size limits
-            unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
-            if (nBlockSize + nTxSize >= nBlockMaxSize)
-                continue;
-
-            // Legacy limits on sigOps:
-            unsigned int nTxSigOps = GetLegacySigOpCount(tx);
-            if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
-                continue;
-
-            // Timestamp limit
-            if (tx.nTime > GetAdjustedTime() || (true && tx.nTime > pblock->vtx[0].nTime))
-                continue;
-
-            // Skip free transactions if we're past the minimum block size:
-            if (fSortedByFee && (dFeePerKb < nMinTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
-                continue;
-
-            // Prioritize by fee once past the priority size or we run out of high-priority
-            // transactions:
-            if (!fSortedByFee &&
-                ((nBlockSize + nTxSize >= nBlockPrioritySize) || (dPriority < COIN * 144 / 250)))
-            {
-                fSortedByFee = true;
-                comparer = TxPriorityCompare(fSortedByFee);
-                std::make_heap(vecPriority.begin(), vecPriority.end(), comparer);
-            }
-
-            // Connecting shouldn't fail due to dependency on other memory pool transactions
-            // because we're already processing them in order of dependency
-            map<uint256, CTxIndex> mapTestPoolTmp(mapTestPool);
-            MapPrevTx mapInputs;
-
-            bool fInvalid;
-            CTransactionPoS txPoS;
-            if (!txPoS.FetchInputs(tx, txdb, mapTestPoolTmp, false, true, mapInputs, fInvalid))
-                continue;
-
-            CAmount nTxFees = txPoS.GetValueIn(tx, mapInputs) - txPoS.GetValueOut(tx);
-
-            nTxSigOps += GetP2SHSigOpCount(tx, mapInputs);
-            if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
-                continue;
-
-            // Note that flags: we don't want to set mempool/IsStandard()
-            // policy here, but we still have to ensure that the block we
-            // create only contains transactions that are valid in new blocks.
-            if (!txPoS.ConnectInputs(tx, txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1,1,1), pindexPrev, false, true, MANDATORY_SCRIPT_VERIFY_FLAGS))
-                continue;
-
-            mapTestPoolTmp[tx.GetHash()] = CTxIndex(CDiskTxPos(1,1,1), tx.vout.size());
-            swap(mapTestPool, mapTestPoolTmp);
-
-            // Added
-            pblock->vtx.push_back(tx);
-            nBlockSize += nTxSize;
-            ++nBlockTx;
-            nBlockSigOps += nTxSigOps;
-            nFees += nTxFees;
-
-            if (fDebug && GetBoolArg("-printpriority", false))
-            {
-                LogPrintf("priority %.1f feeperkb %.1f txid %s\n",
-                       dPriority, dFeePerKb, tx.GetHash().ToString());
-            }
-
-            // Add transactions that depend on this one to the priority queue
-            uint256 hash = tx.GetHash();
-            if (mapDependers.count(hash))
-            {
-                BOOST_FOREACH(COrphan* porphan, mapDependers[hash])
-                {
-                    if (!porphan->setDependsOn.empty())
-                    {
-                        porphan->setDependsOn.erase(hash);
-                        if (porphan->setDependsOn.empty())
-                        {
-                            vecPriority.push_back(TxPriority(porphan->dPriority, porphan->dFeePerKb, porphan->ptx));
-                            std::push_heap(vecPriority.begin(), vecPriority.end(), comparer);
-                        }
-                    }
-                }
-            }
-        }
-
-        nLastBlockTx = nBlockTx;
-        nLastBlockSize = nBlockSize;
-
-        if (fDebug && GetBoolArg("-printpriority", false))
-            LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);
-
-        if (pFees)
-            *pFees = nFees;
-
-        // Fill in header
-        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        pblock->nTime          = max(pindexPrev->GetPastTimeLimit()+1, pblock->GetMaxTransactionTime());
-        pblock->nNonce         = 0;
-    }
-
-    return pblock.release();
-}
-
-// CreateNewBlock: create new proof-of-work block
-CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
+// CreateNewBlock: creates new block using proof-of-work or proof-of-stake
+CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFees)
 {
     // Create new block
     auto_ptr<CBlock> pblock(new CBlock());
@@ -381,11 +121,22 @@ CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
     txNew.vin[0].prevout.SetNull();
     txNew.vout.resize(1);
 
-    pblock->nVersion = 1; // Proof of Work uses Argon2d
-    CPubKey pubkey;
-    if (!reservekey.GetReservedKey(pubkey))
-        return NULL;
-    txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
+    if (!fProofOfStake)
+    {
+        pblock->nVersion = 1; // Proof of Work uses Argon2d
+        CPubKey pubkey;
+        if (!reservekey.GetReservedKey(pubkey))
+            return NULL;
+        txNew.vout[0].scriptPubKey.SetDestination(pubkey.GetID());
+    }
+    else
+    {
+        // Height first in coinbase required for block.version=2
+        txNew.vin[0].scriptSig = (CScript() << nHeight) + COINBASE_FLAGS;
+        assert(txNew.vin[0].scriptSig.size() <= 100);
+
+        txNew.vout[0].SetEmpty();
+    }
 
     // Add our coinbase tx as first transaction
     pblock->vtx.push_back(txNew);
@@ -414,7 +165,8 @@ CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
     if (mapArgs.count("-mintxfee"))
         ParseMoney(mapArgs["-mintxfee"], nMinTxFee);
 
-    pblock->nBits = GetNextTargetRequired(pindexPrev, false);
+    pblock->nBits = GetNextTargetRequired(pindexPrev, fProofOfStake);
+
 
     // Collect memory pool transactions into the block
     CAmount nFees = 0;
@@ -531,7 +283,7 @@ CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
                 continue;
 
             // Timestamp limit
-            if (tx.nTime > GetAdjustedTime() || (false && tx.nTime > pblock->vtx[0].nTime))
+            if (tx.nTime > GetAdjustedTime() || (fProofOfStake && tx.nTime > pblock->vtx[0].nTime))
                 continue;
 
             // Skip free transactions if we're past the minimum block size:
@@ -605,21 +357,21 @@ CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
             }
         }
 
-        // Stormnode and general budget payments
-        FillBlockPayee(txNew, nFees);
-
-        // Make payee
-        if(txNew.vout.size() > 1){
-            pblock->payee = txNew.vout[1].scriptPubKey;
+        if (!fProofOfStake){
+            // PoW block, Stormnode and general budget payments
+            FillBlockPayee(txNew, nFees);
+            if ((fDebug && GetBoolArg("-printpriority", false)))
+                LogPrintf("CreateNewBlock(): PoW, total size %u, height: %u \n", nBlockSize, nHeight);
+        }
+        else {
+            //PoS block, just log, payment tx already set.
+            if ((fDebug && GetBoolArg("-printpriority", false)))
+                LogPrintf("CreateNewBlock(): PoS, total size %u, height: %u \n", nBlockSize, nHeight);
         }
 
-        nLastBlockTx = nBlockTx;
-        nLastBlockSize = nBlockSize;
-        LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);
-
-        // Compute final coinbase transaction.
-        txNew.vin[0].scriptSig = CScript() << nHeight << OP_0;
-        pblock->vtx[0] = txNew;
+        //TODO (Amir): Are these lines needed???
+        //nLastBlockTx = nBlockTx;
+        //nLastBlockSize = nBlockSize;
 
         if (pFees)
             *pFees = nFees;
@@ -627,7 +379,8 @@ CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees)
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
         pblock->nTime          = max(pindexPrev->GetPastTimeLimit()+1, pblock->GetMaxTransactionTime());
-        pblock->UpdateTime(pindexPrev);
+        if (!fProofOfStake)
+            pblock->UpdateTime(pindexPrev);
         pblock->nNonce         = 0;
     }
 
@@ -827,7 +580,7 @@ void ThreadStakeMiner(CWallet *pwallet)
         // Create new block
         //
         CAmount nFees;
-        auto_ptr<CBlock> pblock(CreateNewBlockPoS(reservekey, &nFees));
+        auto_ptr<CBlock> pblock(CreateNewBlock(reservekey, true, &nFees));
         if (!pblock.get())
             return;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -363,6 +363,7 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, CAmount* pFe
         if (!fProofOfStake){
             // PoW block, Stormnode and general budget payments
             FillBlockPayee(txNew, nFees);
+            pblock->vtx[0] = txNew;
             if ((fDebug && GetBoolArg("-printpriority", false)))
                 LogPrintf("CreateNewBlock(): PoW, total size %u, height: %u \n", nBlockSize, nHeight);
         }
@@ -607,7 +608,7 @@ int64_t nHPSTimerStart = 0;
 
 void static PoWMiner(CWallet *pwallet)
 {
-    LogPrintf("Darksilk Wallet miner started\n");
+    LogPrintf("Darksilk wallet miner started\n");
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     RenameThread("pow-miner");
 
@@ -716,14 +717,17 @@ void GeneratePoWCoins(bool fGenerate, CWallet* pwallet, int nThreads)
 
     if (minerThreads != NULL)
     {
-    minerThreads->interrupt_all();
-    delete minerThreads;
-    minerThreads = NULL;
+        minerThreads->interrupt_all();
+        delete minerThreads;
+        minerThreads = NULL;
     }
+
     if (nThreads == 0 || !fGenerate)
-    return;
+        return;
+
     minerThreads = new boost::thread_group();
+
     for (int i = 0; i < nThreads; i++)
-    minerThreads->create_thread(boost::bind(&PoWMiner, pwallet));
+        minerThreads->create_thread(boost::bind(&PoWMiner, pwallet));
 }
 #endif

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -595,3 +595,135 @@ void ThreadStakeMiner(CWallet *pwallet)
             MilliSleep(nMinerSleep);
     }
 }
+
+
+#ifdef ENABLE_WALLET
+//////////////////////////////////////////////////////////////////////////////
+//
+// Internal PoW miner
+//
+double dHashesPerSec = 0.0;
+int64_t nHPSTimerStart = 0;
+
+void static PoWMiner(CWallet *pwallet)
+{
+    LogPrintf("Darksilk Wallet miner started\n");
+    SetThreadPriority(THREAD_PRIORITY_LOWEST);
+    RenameThread("pow-miner");
+
+    // Each thread has its own key and counter
+    CReserveKey reservekey(pwallet);
+    unsigned int nExtraNonce = 0;
+
+    try { while (true) {
+        //
+        // Create new block
+        //
+        unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
+        CBlockIndex* pindexPrev = pindexBest;
+
+        CAmount nFees;
+        auto_ptr<CBlock> pblocktemplate(CreateNewBlock(reservekey, false, &nFees));
+        if (!pblocktemplate.get())
+            return;
+
+        CBlock *pblock = pblocktemplate.get();
+
+        IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
+
+        LogPrintf("Running Darksilk wallet PoW miner with %llu transactions in block (%u bytes)\n", pblock->vtx.size(),
+               ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+
+        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+        int64_t nStart = GetTime();
+        uint256 hash;
+        unsigned int nHashesDone = 0;
+
+        while (true)
+        {
+            hash = pblock->GetPoWHash();
+            ++nHashesDone;
+
+            if (hash <= hashTarget)
+            {
+                // Found a solution
+                SetThreadPriority(THREAD_PRIORITY_NORMAL);
+                CheckWork(pblock, *pwallet, reservekey);
+                SetThreadPriority(THREAD_PRIORITY_LOWEST);
+                break;
+            }
+            ++pblock->nNonce;
+
+            // Meter hashes/sec
+            static int64_t nHashCounter;
+            if (nHPSTimerStart == 0)
+            {
+                nHPSTimerStart = GetTime();
+                nHashCounter = 0;
+            }
+            else
+                ++nHashCounter;// += nHashesDone;
+
+            if ((GetTime() - nHPSTimerStart) % 4 == 0)
+            {
+                static CCriticalSection cs;
+                {
+                    LOCK(cs);
+                    int64_t nDelta = GetTime() - nHPSTimerStart;
+                    if(nDelta > 0)
+                        dHashesPerSec = 32768 * nHashCounter / (GetTime() - nHPSTimerStart);
+                        //nHPSTimerStart = GetTimeMillis();
+                        //nHashCounter = 0;
+                        //nHashesDone = 0;
+                        LogPrintf("hashmeter %6.0f hash/s\n", dHashesPerSec);
+
+                        }
+            }
+
+            // Check for stop or if block needs to be rebuilt
+            boost::this_thread::interruption_point();
+            if (vNodes.empty())
+                break;
+            if (pblock->nNonce >= 0xffff0000)
+                break;
+            if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 60)
+                break;
+            if (pindexPrev != pindexBest)
+                break;
+
+            // Update nTime every few seconds
+            pblock->UpdateTime(pindexPrev);
+
+            if (TestNet())
+            {
+                // Changing pblock->nTime can change work required on testnet:
+                hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+            }
+        }
+    } }
+    catch (boost::thread_interrupted)
+    {
+        LogPrintf("Darksilk wallet PoW miner terminated\n");
+        throw;
+    }
+}
+
+void GeneratePoWCoins(bool fGenerate, CWallet* pwallet, int nThreads)
+{
+    static boost::thread_group* minerThreads = NULL;
+    if(nThreads == -1)
+        nThreads = boost::thread::hardware_concurrency();
+
+    if (minerThreads != NULL)
+    {
+    minerThreads->interrupt_all();
+    delete minerThreads;
+    minerThreads = NULL;
+    }
+    if (nThreads == 0 || !fGenerate)
+    return;
+    minerThreads = new boost::thread_group();
+    for (int i = 0; i < nThreads; i++)
+    minerThreads->create_thread(boost::bind(&PoWMiner, pwallet));
+}
+#endif

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,11 +8,8 @@
 
 #include "wallet/wallet.h"
 
-//! Generate new proof-of-stake block
-CBlock* CreateNewBlockPoS(CReserveKey& reservekey, CAmount* pFees = 0);
-
-//! Generate a new proof-of-work block
-CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees = 0);
+//! Generate new block using proof-of-work or proof-of-stake
+CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake=false, CAmount* pFees = 0);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,8 +8,11 @@
 
 #include "wallet/wallet.h"
 
-/* Generate a new block, without valid proof-of-work */
-CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake=false, CAmount* pFees = 0);
+//! Generate new proof-of-stake block
+CBlock* CreateNewBlockPoS(CReserveKey& reservekey, CAmount* pFees = 0);
+
+//! Generate a new proof-of-work block
+CBlock* CreateNewBlockPoW(CReserveKey& reservekey, CAmount* pFees = 0);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);

--- a/src/miner.h
+++ b/src/miner.h
@@ -26,4 +26,7 @@ bool CheckStake(CBlock* pblock, CWallet& wallet);
 /** Base sha256 mining transform */
 void SHA256Transform(void* pstate, void* pinput, const void* pinit);
 
+//! Run the wallet PoW miner threads
+void GeneratePoWCoins(bool fGenerate, CWallet* pwallet, int nThreads);
+
 #endif // DRKSLK_MINER_H

--- a/src/rpc/rpcblindtext.cpp
+++ b/src/rpc/rpcblindtext.cpp
@@ -104,7 +104,7 @@ Value decryptsend(const Array& params, bool fHelp)
     cout << "Amount is: " << nAmount << endl;
 
     // make sure external transaction is within time window
-    int adjtime = GetAdjustedTime();
+    unsigned int adjtime = GetAdjustedTime();
     if (((nTime < adjtime) && ((adjtime - nTime) > MaxTxnTimeDrift)) ||
         ((nTime > adjtime) && ((nTime - adjtime) > MaxTxnTimeDrift))) {
             return string("<<Bad Timestamp>>");

--- a/src/rpc/rpcclient.cpp
+++ b/src/rpc/rpcclient.cpp
@@ -109,6 +109,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtoaddress", 4 },
     { "sendtoaddress", 5 },
     { "settxfee", 0 },
+    { "setgenerate", 0},
+    { "setgenerate", 1},
     { "getreceivedbyaddress", 1 },
     { "getreceivedbyaccount", 1 },
     { "listreceivedbyaddress", 0 },

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -808,3 +808,29 @@ Value submitblock(const Array& params, bool fHelp)
     return Value::null;
 }
 
+
+Value setgenerate(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+            "setgenerate <generate> [genproclimit]\n"
+            "<generate> is true or false to turn generation on or off.\n"
+            "Generation is limited to [genproclimit] processors, -1 is unlimited.");
+
+    bool fGenerate = true;
+    if (params.size() > 0)
+        fGenerate = params[0].get_bool();
+
+    int nGenProcLimit = 1;
+    if (params.size() > 1)
+    {
+        nGenProcLimit = params[1].get_int();
+        mapArgs["-genproclimit"] = itostr(nGenProcLimit);
+        if (nGenProcLimit == 0)
+            fGenerate = false;
+    }
+    mapArgs["-gen"] = (fGenerate ? "1" : "0");
+
+    GeneratePoWCoins(fGenerate, pwalletMain, nGenProcLimit);
+    return Value::null;
+}

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -214,7 +214,7 @@ Value checkkernel(const Array& params, bool fHelp)
         return result;
 
     int64_t nFees;
-    auto_ptr<CBlock> pblock(CreateNewBlockPoS(*pMiningKey, &nFees));
+    auto_ptr<CBlock> pblock(CreateNewBlock(*pMiningKey, true, &nFees));
 
     pblock->nTime = pblock->vtx[0].nTime = nTime;
 
@@ -274,7 +274,7 @@ Value getworkex(const Array& params, bool fHelp)
             nStart = GetTime();
 
             // Create new block
-            pblock = CreateNewBlockPoW(*pMiningKey);
+            pblock = CreateNewBlock(*pMiningKey);
             if (!pblock)
                 throw JSONRPCError(-7, "Out of memory");
             vNewBlock.push_back(pblock);
@@ -410,7 +410,7 @@ Value getwork(const Array& params, bool fHelp)
             nStart = GetTime();
 
             // Create new block
-            pblock = CreateNewBlockPoW(*pMiningKey);
+            pblock = CreateNewBlock(*pMiningKey);
             if (!pblock)
                 throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
             vNewBlock.push_back(pblock);
@@ -675,7 +675,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
             delete pblock;
             pblock = NULL;
         }
-        pblock = CreateNewBlockPoW(*pMiningKey);
+        pblock = CreateNewBlock(*pMiningKey);
         if (!pblock)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -214,7 +214,7 @@ Value checkkernel(const Array& params, bool fHelp)
         return result;
 
     int64_t nFees;
-    auto_ptr<CBlock> pblock(CreateNewBlock(*pMiningKey, true, &nFees));
+    auto_ptr<CBlock> pblock(CreateNewBlockPoS(*pMiningKey, &nFees));
 
     pblock->nTime = pblock->vtx[0].nTime = nTime;
 
@@ -274,7 +274,7 @@ Value getworkex(const Array& params, bool fHelp)
             nStart = GetTime();
 
             // Create new block
-            pblock = CreateNewBlock(*pMiningKey);
+            pblock = CreateNewBlockPoW(*pMiningKey);
             if (!pblock)
                 throw JSONRPCError(-7, "Out of memory");
             vNewBlock.push_back(pblock);
@@ -410,7 +410,7 @@ Value getwork(const Array& params, bool fHelp)
             nStart = GetTime();
 
             // Create new block
-            pblock = CreateNewBlock(*pMiningKey);
+            pblock = CreateNewBlockPoW(*pMiningKey);
             if (!pblock)
                 throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
             vNewBlock.push_back(pblock);
@@ -675,7 +675,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
             delete pblock;
             pblock = NULL;
         }
-        pblock = CreateNewBlock(*pMiningKey);
+        pblock = CreateNewBlockPoW(*pMiningKey);
         if (!pblock)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -277,6 +277,7 @@ static const CRPCCommand vRPCCommands[] =
     { "snfinalbudget",          &snfinalbudget,          true,      true,      false }, 
     { "stormnodelist",          &stormnodelist,          true,      true,      false },
 #ifdef ENABLE_WALLET
+    { "setgenerate",		    &setgenerate,			 true,		 false,	   true },
     { "sandstorm",              &sandstorm,              false,     false,     true },
     { "getmininginfo",          &getmininginfo,          true,      false,     false },
     { "getstakinginfo",         &getstakinginfo,         true,      false,     false },

--- a/src/rpc/rpcserver.h
+++ b/src/rpc/rpcserver.h
@@ -230,6 +230,7 @@ extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fH
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblockbynumber(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getcheckpoint(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getnewstealthaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value liststealthaddresses(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
#### What's this pull request do?
Changes stormnode selection to use PoW instead of PoS block hashes.  Budget payments also changed to link to PoW block hashes.  Also adds setgenerate to test PoW mining within the wallet.
#### Did you test this pull request?
Yes.  PoS and sending/receiving transactions tested okay.  PoW tested as  well.
#### Any background context you want to provide?
PoS hashes are less random than PoW because the balance is factored into the selection process. Since stormnode payment selection is based on the block hash, it should use PoW instead of PoS.  
#### Questions:
- Does the readme or documentaion need an update? No.
- Does this add new C++ dependencies which need to be added? No.
- Does this change the chain or fork the network? No.

STATIC_POW_REWARD in main.h should be changed to 1.25 so the split is 1.0 to the miner and 0.25 to the stormnode.  It is currently set to 1.0 so it doesn't fork our testnet.