### PR TITLE
compat.h changes for closesocket

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -23,7 +23,6 @@
 #define FD_SETSIZE 1024 // max number of fds in fd_set
 
 #include <winsock2.h>     // Must be included before mswsock.h and windows.h
-
 #include <mswsock.h>
 #include <windows.h>
 #include <ws2tcpip.h>
@@ -94,4 +93,18 @@ bool static inline IsSelectableSocket(SOCKET s) {
 #endif
 }
 
+inline int myclosesocket(SOCKET& hSocket)
+{
+ if (hSocket == INVALID_SOCKET)
+     return WSAENOTSOCK;
+#ifdef WIN32
+ int ret = closesocket(hSocket);
+#else
+ int ret = close(hSocket);
+#endif
+ hSocket = INVALID_SOCKET;
+ return ret;
+}
+#define closesocket(s)      myclosesocket(s)
+ 
 #endif


### PR DESCRIPTION
#### What's this pull request do?
Adds inline int myclosesocket to compat.h to fix non-declaration of closesocket when building for Windows.
#### Did you test this pull request?
Qt and Daemon build and connect successfully.
#### Any background context you want to provide?
Working off of Cisahasa's error log and messages.
#### Questions:
- Does the readme or documentaion need an update? No
- Does this add new C++ dependencies which need to be added? No
- Does this change the chain or fork the network? No

