### PR TITLE
use lower-case windows.h

### DIFF
--- a/src/crypto/argon2/thread.c
+++ b/src/crypto/argon2/thread.c
@@ -1,6 +1,6 @@
 #include "thread.h"
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 int argon2_thread_create(argon2_thread_handle_t *handle,


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?
use lower-case "windows.h"
Capitalized Windows.h breaks on MinGW. "windows.h" is the proper include.

#### Any background context to help the reviewer?
https://github.com/P-H-C/phc-winner-argon2/commit/8a86be605acd6ebe684650b5e860776145200d2b

#### Was this PR tested and how (if not, why)?
Builds tested locally and on Travis, functionality not tested.

#### More Questions:
- Does the knowledge base need an update? No
- Does this PR add or change dependencies? No
- Does this change the chain or fork the network? No